### PR TITLE
Convert .env file provisioning to manual step

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ D4M is slow. Primarily because of its osxfs/grpcfuse sharing filesystem. On the 
 1. Install and set up vagrant VM:
     ```bash
     ./setup.sh
+    cp .env.dist .env
     ```
 2. Set your preferred shared folder in the `.env` file, for example `SHARE_PATH="$HOME/Sites/"`
 3. Thats it, start vagrant with `vagrant up`.

--- a/setup.sh
+++ b/setup.sh
@@ -3,13 +3,3 @@
 brew install vagrant
 vagrant plugin install vagrant-parallels
 vagrant plugin install vagrant-env
-
-if [ ! -f .env ]; then
-    cp .env.dist .env
-fi
-
-source .env
-
-if [ ! -d "$SHARE_PATH" ]; then
-    mkdir -p "$SHARE_PATH"
-fi


### PR DESCRIPTION
Performing this step manually should improve understandability of how how the system works.

This should resolve a potential tripping point @markomitranic raised in his comment here: https://github.com/markomitranic/docker-mac-vagrant/pull/4#discussion_r735793942