### PR TITLE
fix trigger up on catalina 10.15.7 and iterm2

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -2,4 +2,4 @@
 
 curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose
-ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose


### PR DESCRIPTION
was getting errors with original sed, was missing hosts entry which caused error and was unable to vagrant provision after the fact due to the existing symlink