### PR TITLE
Tilda in path not understood

### DIFF
--- a/trigger-halt.sh
+++ b/trigger-halt.sh
@@ -8,7 +8,7 @@ if [ -z "$BOX_NAME" ]; then
     exit 1
 fi
 
-VAGRANT_BOX_IP=$(grep -i HostName "~/.ssh/config.d/${BOX_NAME}" | awk '{print $NF}' || true)
+VAGRANT_BOX_IP=$(grep -i HostName "$HOME/.ssh/config.d/${BOX_NAME}" | awk '{print $NF}' || true)
 
 docker context use default
 

--- a/trigger-up.sh
+++ b/trigger-up.sh
@@ -33,7 +33,7 @@ else
     echo "No need to modify '$HOME/.ssh/config'. Continuing..."
 fi
 
-ssh-keyscan -H "$BOX_NAME" >> ~/.ssh/known_hosts
+ssh-keyscan -H "$BOX_NAME" >> "$HOME/.ssh/known_hosts"
 
 docker context create "$BOX_NAME" --docker "host=ssh://vagrant@${BOX_NAME}" || true
 docker context use "$BOX_NAME" || true


### PR DESCRIPTION
Having tilda in path here results in following error when stopping a vagrant VM:

    grep: ~/.ssh/config.d/dockerbox: No such file or directory