### PR TITLE
Trigger keyscan on vagrant VM IP

### DIFF
--- a/trigger-up.sh
+++ b/trigger-up.sh
@@ -35,6 +35,11 @@ fi
 
 ssh-keyscan -H "$BOX_NAME" >> ~/.ssh/known_hosts
 
+VAGRANT_BOX_IP=$(grep -i HostName "$HOME/.ssh/config.d/${BOX_NAME}" | awk '{print $NF}' || true)
+if [ ! -z "$VAGRANT_BOX_IP" ]; then
+    ssh-keyscan -H "$VAGRANT_BOX_IP" >> "$HOME/.ssh/known_hosts"
+fi
+
 docker context create "$BOX_NAME" --docker "host=ssh://vagrant@${BOX_NAME}" || true
 docker context use "$BOX_NAME" || true
 


### PR DESCRIPTION
When `trigger-halt.sh` is invoked by `vagrant halt` or `destroy`, it will report error like:

    Host 10.x.y.z not found in $HOME/.ssh/known_hosts

This ensures that the IP address is keyscanned as well as the hostname before it during `vagrant up`. It should help future-proofing all SSH interactions a little bit.