### PR TITLE
Revert "Convert .env file provisioning to manual step"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ D4M is slow. Primarily because of its osxfs/grpcfuse sharing filesystem. On the 
 1. Install and set up vagrant VM:
     ```bash
     ./setup.sh
-    cp .env.dist .env
     ```
 2. Set your preferred shared folder in the `.env` file, for example `SHARE_PATH="$HOME/Sites/"`
 3. Thats it, start vagrant with `vagrant up`.

--- a/setup.sh
+++ b/setup.sh
@@ -3,3 +3,13 @@
 brew install vagrant
 vagrant plugin install vagrant-parallels
 vagrant plugin install vagrant-env
+
+if [ ! -f .env ]; then
+    cp .env.dist .env
+fi
+
+source .env
+
+if [ ! -d "$SHARE_PATH" ]; then
+    mkdir -p "$SHARE_PATH"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -8,8 +8,13 @@ if [ ! -f .env ]; then
     cp .env.dist .env
 fi
 
-source .env
+echo
+echo 'Contents of your .env file:'
 
-if [ ! -d "$SHARE_PATH" ]; then
-    mkdir -p "$SHARE_PATH"
-fi
+cat .env
+
+echo
+echo 'Please review variables defined in .env file shown above.'
+echo 'If you need to make any adjustments, edit .env file now!'
+echo 'For example, you might want to adjust SHARE_PATH to where'
+echo 'your work directory resides.'


### PR DESCRIPTION
Reverts markomitranic/docker-mac-vagrant#5

I merged it without waiting for a https://github.com/markomitranic/docker-mac-vagrant/pull/5#issuecomment-962676839 from @markomitranic. Sorry!