### PR TITLE
Remove ssh-keyscan on vagrant up/halt

### DIFF
--- a/trigger-halt.sh
+++ b/trigger-halt.sh
@@ -8,17 +8,10 @@ if [ -z "$BOX_NAME" ]; then
     exit 1
 fi
 
-VAGRANT_BOX_IP=$(grep -i HostName "$HOME/.ssh/config.d/${BOX_NAME}" | awk '{print $NF}' || true)
-
 docker context use default
 
 if docker context inspect "$BOX_NAME" > /dev/null; then
     docker context rm "$BOX_NAME" || true
-fi
-
-ssh-keygen -R "$BOX_NAME" || true
-if [ ! -z "$VAGRANT_BOX_IP" ]; then
-    ssh-keygen -R "$VAGRANT_BOX_IP"
 fi
 
 rm -f "$HOME/.ssh/config.d/${BOX_NAME}"

--- a/trigger-up.sh
+++ b/trigger-up.sh
@@ -33,13 +33,6 @@ else
     echo "No need to modify '$HOME/.ssh/config'. Continuing..."
 fi
 
-ssh-keyscan -H "$BOX_NAME" >> "$HOME/.ssh/known_hosts"
-
-VAGRANT_BOX_IP=$(grep -i HostName "$HOME/.ssh/config.d/${BOX_NAME}" | awk '{print $NF}' || true)
-if [ ! -z "$VAGRANT_BOX_IP" ]; then
-    ssh-keyscan -H "$VAGRANT_BOX_IP" >> "$HOME/.ssh/known_hosts"
-fi
-
 docker context create "$BOX_NAME" --docker "host=ssh://vagrant@${BOX_NAME}" || true
 docker context use "$BOX_NAME" || true
 


### PR DESCRIPTION
SSH configuration generated via `vagrant ssh-config` defines a couple of ssh client options that prevent ssh client from ever checking remote ssh server fingerprints. Thus, when docker CLI invokes ssh client, fingerprints will not be checked for, and that effectively negates the need to perform `ssh-keyscan` at all.

It might not be the smartest thing in the world, but that's how it is.