### PR TITLE
Add plugin: vagrant-hostmanager

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,12 @@
 Vagrant.configure("2") do |config|
   # Load variables from .env
   config.env.enable
+
+  # Configure hostmanager to update /etc/hosts
+  config.hostmanager.enabled = true
+  config.hostmanager.manage_host = true
+  config.hostmanager.manage_guest = true
+
   env_box_name = ENV["BOX_NAME"]
   env_ram = ENV["RAM_MEMORY"]
   env_cpus = ENV["CPU_COUNT"]

--- a/setup.sh
+++ b/setup.sh
@@ -23,12 +23,13 @@ if [ ! -f .env ]; then
 fi
 
 echo
-echo 'Contents of your .env file:'
+echo '>> Contents of your .env file:'
+echo
 
 cat .env
 
 echo
-echo 'Please review variables defined in .env file shown above.'
-echo 'If you need to make any adjustments, edit .env file now!'
-echo 'For example, you might want to adjust SHARE_PATH to where'
-echo 'your work directory resides.'
+echo '>> Please review variables defined in .env file shown above.'
+echo '>> If you need to make any adjustments, edit .env file now!'
+echo '>> For example, you might want to adjust SHARE_PATH to where'
+echo '>> your work directory resides.'

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,19 @@ vagrant plugin install vagrant-parallels
 vagrant plugin install vagrant-env
 vagrant plugin install vagrant-hostmanager
 
+if [ ! -f /etc/sudoers.d/vagrant_hostmanager ]; then
+    echo
+    echo '>> This script will create /etc/sudoers.d/vagrant_hostmanager file in order'
+    echo '>> to allow vagrant-hostmanager plugin to do its job.'
+    echo '>> You will also see the contents of the vagrant_hostmanager file.'
+    echo
+
+    sudo tee /etc/sudoers.d/vagrant_hostmanager <<-EOF
+    Cmnd_Alias VAGRANT_HOSTMANAGER_UPDATE = /bin/cp ${HOME}/.vagrant.d/tmp/hosts.local /etc/hosts
+    %admin ALL=(root) NOPASSWD: VAGRANT_HOSTMANAGER_UPDATE
+EOF
+fi
+
 if [ ! -f .env ]; then
     cp .env.dist .env
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,7 @@
 brew install vagrant
 vagrant plugin install vagrant-parallels
 vagrant plugin install vagrant-env
+vagrant plugin install vagrant-hostmanager
 
 if [ ! -f .env ]; then
     cp .env.dist .env


### PR DESCRIPTION
[vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager) plugin automates the task of maintaining `/etc/hosts` file both on the host OS and within guest OS (within VM), in order to make `workbox` (default value of `BOX_NAME`, defined via `.env`) available equally from everywhere.

This used to be automatically managed by vagrant, but ever since I upgraded to macOS Monterey and upgraded Parallels to v17, it stopped working for me.

There are a few plugins providing relevant features, but vagrant-hostmanager plugin seems to be the only plugin that is still maintained. (The other one I found is abandoned: [vagrant-hostsupdater](https://github.com/agiledivider/vagrant-hostsupdater)).