### PR TITLE
Upgrade vagrant box to Ubuntu 21.10

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   
-  config.vm.box = "bento/ubuntu-20.04"
+  config.vm.box = "bento/ubuntu-21.10"
   config.vm.define env_box_name
   config.vm.hostname = env_box_name
   config.vm.synced_folder env_share_path, env_share_path


### PR DESCRIPTION
New ubuntu box is built using Parallels v17, which is the latest version of Parallels built to run on macOS Monterey.